### PR TITLE
Allow IntegrationTest to be formatted by Scalariform (v1.0.1)

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -22,19 +22,24 @@ import scalariform.formatter.preferences.{ FormattingPreferences, IFormattingPre
 
 object SbtScalariform extends Plugin {
 
+  def scalariformSettingsWithIt: Seq[Setting[_]] = {
+    import ScalariformKeys._
+    import Scalariform._
+    scalariformSettings ++ Seq(compileInputs in IntegrationTest <<= (compileInputs in IntegrationTest) dependsOn (format in IntegrationTest)) ++ inConfig(IntegrationTest)(needToBeScopedScalariformSettings)
+  }
+
   def scalariformSettings: Seq[Setting[_]] = {
     import ScalariformKeys._
     defaultScalariformSettings ++ Seq(
       compileInputs in (Compile, compile) <<= (compileInputs in (Compile, compile)) dependsOn (format in Compile),
-      compileInputs in Test <<= (compileInputs in Test) dependsOn (format in Test),
-      compileInputs in IntegrationTest <<= (compileInputs in IntegrationTest) dependsOn (format in IntegrationTest)
+      compileInputs in Test <<= (compileInputs in Test) dependsOn (format in Test)
     )
   }
 
   def defaultScalariformSettings: Seq[Setting[_]] = {
     import Scalariform._
     val needToBeScoped = needToBeScopedScalariformSettings
-    noNeedToBeScopedScalariformSettings ++ inConfig(Compile)(needToBeScoped) ++ inConfig(Test)(needToBeScoped) ++ inConfig(IntegrationTest)(needToBeScoped)
+    noNeedToBeScopedScalariformSettings ++ inConfig(Compile)(needToBeScoped) ++ inConfig(Test)(needToBeScoped)
   }
 
   object ScalariformKeys {


### PR DESCRIPTION
Scalariform is not formatting IT test folder:
 src/it

Adding IntegrationTest to compileInputs and inConfig will allow Scalariform to run when performing it:compile or it:test.
