### PR TITLE
Version 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To add sbt-scalariform to your build using sbt 0.13, just add the below setting,
 ```
 ... // Other settings
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.4.0")
 ```
 
 To add sbt-scalariform to your build using sbt 0.12:
@@ -69,7 +69,6 @@ scalariformSettings
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
   .setPreference(DoubleIndentClassDeclaration, true)
-  .setPreference(PreserveDanglingCloseParenthesis, true)
 ```
 
 If you don't want sbt to automatically format your source files when the tasks `compile` or `test:compile`, just add `defaultScalariformSettings` instead of `scalariformSettings` to your build definition.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Version {
-  val scalariform = "0.1.4"
+  val scalariform = "0.1.7"
 }
 
 object Library {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")

--- a/scalariform.sbt
+++ b/scalariform.sbt
@@ -5,4 +5,3 @@ scalariformSettings
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
   .setPreference(DoubleIndentClassDeclaration, true)
-  .setPreference(PreserveDanglingCloseParenthesis, true)

--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -46,8 +46,8 @@ object SbtScalariform extends Plugin {
   val defaultPreferences = {
     import scalariform.formatter.preferences._
     FormattingPreferences()
+      .setPreference(AlignSingleLineCaseStatements, true)
       .setPreference(DoubleIndentClassDeclaration, true)
-      .setPreference(PreserveDanglingCloseParenthesis, true)
   }
 
   def scalariformSettings: Seq[Setting[_]] =

--- a/src/main/scala/com/typesafe/sbt/Scalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/Scalariform.scala
@@ -33,7 +33,8 @@ private object Scalariform {
     ref: ProjectRef,
     configuration: Configuration,
     streams: TaskStreams,
-    scalaVersion: String): Seq[File] = {
+    scalaVersion: String
+  ): Seq[File] = {
 
     def log(label: String, logger: Logger)(message: String)(count: String) =
       logger.info(message.format(count, label))
@@ -65,7 +66,8 @@ private object Scalariform {
     files: Set[File],
     cache: File,
     logFun: String => Unit,
-    updateFun: Set[File] => Unit): Set[File] = {
+    updateFun: Set[File] => Unit
+  ): Set[File] = {
 
     def handleUpdate(in: ChangeReport[File], out: ChangeReport[File]) = {
       val files = in.modified -- in.removed

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "1.4.0-SNAPSHOT"
+version in ThisBuild := "1.4.0"


### PR DESCRIPTION
- Upgrading scalariform to 0.1.7
- Upgrading sbt to 0.13.9
- Using sbt-scalariform 1.3.0 instead of 1.1.0
- Removing PreserveDanglingCloseParenthesis deprecated option
- Code formatting using sbt-scalariform 1.3.0