### PR TITLE
Fix doc: task name for include and exclude filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ If you want to additionally enable Scalariform for your integration tests, use `
 
 Other useful configuration options are provided by common sbt setting keys:
 
-- `includeFilter in format`: Defaults to **.scala*
-- `excludeFilter in format`: Using the default of sbt
+- `includeFilter in scalariformFormat`: Defaults to **.scala*
+- `excludeFilter in scalariformFormat`: Using the default of sbt
 
 Contact
 ------------


### PR DESCRIPTION
These don't compile anymore:

```scala
includeFilter in format
excludeFilter in format
```

But these do:

```scala
includeFilter in scalariformFormat
excludeFilter in scalariformFormat
```