### PR TITLE
Skip formatting managed sources gen'ed by Play!

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -84,7 +84,7 @@ object SbtScalariform extends AutoPlugin {
 
   def configScalariformSettings: Seq[Setting[_]] =
     List(
-      (sourceDirectories in Global in scalariformFormat) := List(scalaSource.value),
+      (sourceDirectories in scalariformFormat) := List(scalaSource.value),
       scalariformFormat := Scalariform(
         scalariformPreferences.value,
         (sourceDirectories in scalariformFormat).value.toList,


### PR DESCRIPTION
This is a fix for #32 that I was also hitting when using this plugin on a play project.

Now that the generated files are properly skipped, things are much more zippy 😸 

Is it possible to cut a quick release with this fix?
