### PR TITLE
Use unmanagedSourceDirectories for sourceDirectories

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -84,7 +84,7 @@ object SbtScalariform extends AutoPlugin {
 
   def configScalariformSettings: Seq[Setting[_]] =
     List(
-      (sourceDirectories in Global in scalariformFormat) := List(scalaSource.value),
+      (sourceDirectories in Global in scalariformFormat) := unmanagedSourceDirectories.value,
       scalariformFormat := Scalariform(
         scalariformPreferences.value,
         (sourceDirectories in scalariformFormat).value.toList,


### PR DESCRIPTION
`sourceDirectories in scalariformFormat` is currently initialized
with `List(scalaSource.value)` which means that sbt-scalariform only
looks into one source directory per project. But a typical Scala.js
cross project has at least two source directories: js/ and shared/
or jvm/ and shared/. In other projects there are multiple source
directories for different Scala versions.

This change initializes `sourceDirectories in scalariformFormat`
with `unmanagedSourceDirectories` which contains all source
directories with manually created sources. This setting always
includes `scalaSource` because sbt defines it as:

```scala
unmanagedSourceDirectories := makeCrossSources(
  scalaSource.value,
  javaSource.value,
  scalaBinaryVersion.value,
  crossPaths.value)
```

Here are for example both settings for typelevel/cats:

> coreJVM/scalaSource
[info] cats/core/.jvm/src/main/scala

> coreJVM/unmanagedSourceDirectories
[info] List(
  cats/core/.jvm/src/main/scala-2.11,
  cats/core/.jvm/src/main/scala,
  cats/core/.jvm/src/main/java,
  cats/core/src/main/scala)

And since cats has no sources in cats/core/.jvm/src/main/scala
(all sources are in cats/core/src/main/scala), sbt-scalariform
won't format anything.

This change has been tested successfully with one of my projects
and allowed to get rid of this [workaround](https://github.com/fthomas/refined/blob/8e5fad238524dc4bc32401e37d006705f937f280/build.sbt#L337-L340)
to pick up all relevant source directories.