### PR TITLE
Fixed autoformat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,24 @@ Configuration (build.sbt)
 
 Imports
 ```
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 ```
 
-Example Preferences
+Example Preferences:
+
 ```
-val preferences =
-  ScalariformKeys.preferences := ScalariformKeys.preferences.value
+scalariformPreferences := scalariformPreferences.value
     .setPreference(AlignSingleLineCaseStatements, true)
     .setPreference(DoubleIndentConstructorArguments, true)
     .setPreference(DanglingCloseParenthesis, Preserve)
 ```
 
-Sources are automatically formatted on `compile` and `test:compile` by default, just add formatting preferences to the build:
-```
-Seq(preferences)
-```
+Sources are automatically formatted on `compile` and `test:compile` by default.
 
 To enable Scalariform for integration tests in addition to `compile` and `test:compile` add to the build:
+
 ```
-scalariformSettingsWithIt(autoformat = true)
-Seq(preferences)
+scalariformItSettings
 ```
 
 Other useful configuration options are provided by sbt setting keys:
@@ -64,9 +60,9 @@ Disable Autoformatting
 There are two ways to disable autoformatting: in the build, or in a `.scalariform.conf` preferences file.
 
 Build
+
 ```
-scalariformSettings(autoformat = false)
-Seq(preferences)
+scalariformAutoformat := false
 ```
 
 Filesystem

--- a/src/sbt-test/sbt-scalariform/build-prefs-no-autoformat/build.sbt
+++ b/src/sbt-test/sbt-scalariform/build-prefs-no-autoformat/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 name := "test"
 version := "0.1"
 
-scalariformSettings(autoformat = false)
+scalariformAutoformat := false
 
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(AlignArguments, true)


### PR DESCRIPTION
Fixes #74

Autoformat is now configured the way sbt is meant to be used (ie, using a setting).

Also put global settings in the auto plugin global settings, rather than putting them into the project settings. Also modified IT settings so that they only add it scoped settings (since the test and compile settings are already added automatically via projectSettings, so no need to add them twice when configuring IT settings).