### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 jdk: openjdk8
-scala: 2.10.7
 sudo: false
 
 # Build only master and version tags - http://stackoverflow.com/a/31882307/463761

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-jdk: openjdk6
+jdk: openjdk8
 scala: 2.10.6
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk: openjdk8
-scala: 2.10.6
+scala: 2.10.7
 sudo: false
 
 # Build only master and version tags - http://stackoverflow.com/a/31882307/463761

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ scalacOptions ++= List(
   "-encoding", "UTF-8"
 ) ++ (if (scalaVersion.value startsWith "2.10.") List("-target:jvm-1.6") else List.empty)
 
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.2.5"
+libraryDependencies += "org.scalariform" %% "scalariform" % "0.2.10"
 
 com.typesafe.sbt.SbtScalariform.ScalariformKeys.preferences := {
   import scalariform.formatter.preferences._

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ version in ThisBuild := "1.8.2"
     )
   )
 
-crossSbtVersions := Vector("0.13.16", "1.0.3")
+crossSbtVersions := Vector("0.13.18", "1.2.8")
 
 scalacOptions ++= List(
   "-unchecked",
@@ -50,6 +50,7 @@ com.typesafe.sbt.SbtScalariform.ScalariformKeys.preferences := {
 // preserve formatting of sbt-scripted test files
 excludeFilter in scalariformFormat := "unformatted.scala" || "formatted.scala"
 
+enablePlugins(SbtPlugin)
 scriptedLaunchOpts := {
   val sbtAssemblyVersion = "0.14.5"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")


### PR DESCRIPTION
Applying this PR will update all dependencies, and make the travis build pass again.
Makes #79 obsolete.
It would be nice if a new release could be published as well, as scalariform 0.2.10 contains https://github.com/scala-ide/scalariform/pull/280.